### PR TITLE
Ability to register custom Legate build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Legate.jl is not on the general registry yet. To add Legate.jl to your environme
 using Pkg; Pkg.add(url = "https://github.com/JuliaLegate/Legate.jl", rev = "main")
 ```
 
+## 2b. Use preinstalled version of [Legate](https://github.com/nv-legate/legate)
+We support using a custom install version of Legate. See https://docs.nvidia.com/legate/latest/installation.html for details about different install configurations.
+```bash
+export LEGATE_CUSTOM_INSTALL=1
+export LEGATE_CUSTOM_INSTALL_LOCATION="/home/user/path/to/legate-install-dir"
+```
+
 ## Contact
 For technical questions, please either contact 
 `krasow(at)u.northwestern.edu` OR


### PR DESCRIPTION
In order to use a custom Legate install https://docs.nvidia.com/legate/latest/installation.html, you must export two separate ENV variables. build.jl will detect the ENV variables and select the right install. If you have an unsupported version, we will fallback to legate_jll inorder to build. 

```bash
export LEGATE_CUSTOM_INSTALL=1
export LEGATE_CUSTOM_INSTALL_LOCATION="/home/user/path/to/legate-install-dir"
```