### PR TITLE
Conda Build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Julia Bindings for nv-legate
 curl -fsSL https://install.julialang.org | sh -s -- --default-channel 1.10
 ```
 
-This will install version 1.10 by default since that is what we have tested against. To verify 1.10 is the default run either of the following (your may need to source bashrc):
+This will install version 1.10 by default since that is what we have tested against. To verify 1.10 is the default run either of the following (you may need to source bashrc):
 ```bash
 juliaup status
 julia --version
@@ -33,12 +33,40 @@ Legate.jl is not on the general registry yet. To add Legate.jl to your environme
 ```julia
 using Pkg; Pkg.add(url = "https://github.com/JuliaLegate/Legate.jl", rev = "main")
 ```
+The `rev` option can be main or any tagged version.  By default, this will use [legate_jll](https://github.com/ejmeitz/legate_jll.jl). In [2b](#2b-use-preinstalled-version-of-legate) and [2c](#2c-use-a-conda-environment-to-install-legatejl), we show different installation methods. Ensure that the enviroment variables are correctly set for custom builds.
+
+To contribute to Legate.jl, we recommend cloning the repository and manually triggering the build process with `Pkg.build` or adding it to one of your existing environments with `Pkg.develop`.
+```bash
+git clone https://github.com/JuliaLegate/Legate.jl.git
+cd Legate.jl
+julia -e 'using Pkg; Pkg.activate(".") Pkg.resolve(); Pkg.build()'
+```
 
 #### 2b. Use preinstalled version of [Legate](https://github.com/nv-legate/legate)
 We support using a custom install version of Legate. See https://docs.nvidia.com/legate/latest/installation.html for details about different install configurations.
 ```bash
 export LEGATE_CUSTOM_INSTALL=1
 export LEGATE_CUSTOM_INSTALL_LOCATION="/home/user/path/to/legate-install-dir"
+```
+```julia
+using Pkg; Pkg.add(url = "https://github.com/JuliaLegate/Legate.jl", rev = "main")
+```
+
+#### 2c. Use a conda environment to install Legate.jl
+Note, you need conda >= 24.1 to install the conda package. More installation details are found [here](https://docs.nvidia.com/legate/latest/installation.html).
+```bash
+# with a new environment
+conda create -n myenv -c conda-forge -c legate legate
+# into an existing environment
+conda install -c conda-forge -c legate legate
+```
+Once you have the conda package installed, you can activate here. 
+```bash
+conda activate [conda-env-with-legate]
+export CUNUMERIC_LEGATE_CONDA_INSTALL=1
+```
+```julia
+using Pkg; Pkg.add(url = "https://github.com/JuliaLegate/Legate.jl", rev = "main")
 ```
 
 ## Contact


### PR DESCRIPTION
#### 2c. Use a conda environment to install Legate.jl
Note, you need conda >= 24.1 to install the conda package. More installation details are found [here](https://docs.nvidia.com/legate/latest/installation.html).
```bash
# with a new environment
conda create -n myenv -c conda-forge -c legate legate
# into an existing environment
conda install -c conda-forge -c legate legate
```
Once you have the conda package installed, you can activate here. 
```bash
conda activate [conda-env-with-legate]
export CUNUMERIC_LEGATE_CONDA_INSTALL=1
```
```julia
using Pkg; Pkg.add(url = "https://github.com/JuliaLegate/Legate.jl", rev = "main")
```